### PR TITLE
refactored to latest Cooja

### DIFF
--- a/cooja-plugin/cooja.config
+++ b/cooja-plugin/cooja.config
@@ -1,2 +1,2 @@
-se.sics.cooja.GUI.PLUGINS = + de.fau.cooja.plugins.realsim.RealSimLive de.fau.cooja.plugins.springlayout.SpringLayout de.fau.cooja.plugins.realsim.RealSimFile
-se.sics.cooja.GUI.JARFILES = + realsim.jar
+org.contikios.cooja.Cooja.PLUGINS = + de.fau.cooja.plugins.realsim.RealSimLive de.fau.cooja.plugins.springlayout.SpringLayout de.fau.cooja.plugins.realsim.RealSimFile
+org.contikios.cooja.Cooja.JARFILES = + realsim.jar


### PR DESCRIPTION
Refactored because of the newest Cooja refactoring.
Renamed from se.sics.cooja.GUI to org.contikios.cooja.Cooja
